### PR TITLE
feature: 네이버 부동산 지도 Client 추가

### DIFF
--- a/src/modules/naver-land-client/clients/index.ts
+++ b/src/modules/naver-land-client/clients/index.ts
@@ -1,3 +1,4 @@
 export * from './naver-land.client.abstract';
 export * from './cluster';
 export * from './front';
+export * from './map';

--- a/src/modules/naver-land-client/clients/map/dtos/get-region-list.response.dto.ts
+++ b/src/modules/naver-land-client/clients/map/dtos/get-region-list.response.dto.ts
@@ -1,0 +1,10 @@
+import { CortarItem } from '../naver-land-map.interface';
+
+export class GetRegionListResponseDto {
+    result: {
+        list: CortarItem[];
+        dvsnInfo?: CortarItem;
+        cityInfo?: CortarItem;
+        secInfo?: CortarItem;
+    };
+}

--- a/src/modules/naver-land-client/clients/map/dtos/index.ts
+++ b/src/modules/naver-land-client/clients/map/dtos/index.ts
@@ -1,0 +1,1 @@
+export * from './get-region-list.response.dto';

--- a/src/modules/naver-land-client/clients/map/index.ts
+++ b/src/modules/naver-land-client/clients/map/index.ts
@@ -1,0 +1,3 @@
+export * from './dtos';
+export * from './naver-land-map.interface';
+export * from './naver-land-map.client';

--- a/src/modules/naver-land-client/clients/map/naver-land-map.client.ts
+++ b/src/modules/naver-land-client/clients/map/naver-land-map.client.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { GetRegionListResponseDto } from './dtos';
+import { NaverLandClientAbstract } from '../naver-land.client.abstract';
+
+@Injectable()
+export class NaverLandMapClient extends NaverLandClientAbstract {
+    constructor() {
+        super('https://m.land.naver.com');
+    }
+
+    /**
+     *
+     * @param cortarNo
+     */
+    public async getRegionList(
+        cortarNo: string,
+    ): Promise<GetRegionListResponseDto> {
+        return this.call<GetRegionListResponseDto>({
+            method: 'GET',
+            path: '/map/getRegionList',
+            queryParams: {
+                cortarNo,
+            },
+        });
+    }
+}

--- a/src/modules/naver-land-client/clients/map/naver-land-map.interface.ts
+++ b/src/modules/naver-land-client/clients/map/naver-land-map.interface.ts
@@ -1,0 +1,13 @@
+export enum CortarType {
+    Sec = 'sec',
+    Dvsn = 'dvsn',
+    City = 'city',
+}
+
+export interface CortarItem {
+    CortarNo: string;
+    CortarNm: string;
+    MapXCrdn: string;
+    MapYCrdn: string;
+    CortarType: CortarType;
+}

--- a/src/modules/naver-land-client/clients/map/tests/naver-land-map.client.spec.ts
+++ b/src/modules/naver-land-client/clients/map/tests/naver-land-map.client.spec.ts
@@ -1,0 +1,21 @@
+import { Test } from '@nestjs/testing';
+import { NaverLandClientModule } from '../../../naver-land-client.module';
+import { NaverLandMapClient } from '../naver-land-map.client';
+
+describe('NaverLandMapClient', () => {
+    let naverLandMapClient: NaverLandMapClient;
+
+    beforeAll(async () => {
+        const module = await Test.createTestingModule({
+            imports: [NaverLandClientModule],
+        }).compile();
+
+        naverLandMapClient = module.get<NaverLandMapClient>(NaverLandMapClient);
+    });
+
+    it('getRegionList', async () => {
+        const response = await naverLandMapClient.getRegionList('1156000000');
+
+        expect(response.result).toBeDefined();
+    });
+});

--- a/src/modules/naver-land-client/naver-land-client.module.ts
+++ b/src/modules/naver-land-client/naver-land-client.module.ts
@@ -1,7 +1,15 @@
 import { Module } from '@nestjs/common';
-import { NaverLandClusterClient, NaverLandFrontClient } from './clients';
+import {
+    NaverLandClusterClient,
+    NaverLandFrontClient,
+    NaverLandMapClient,
+} from './clients';
 
-const clients = [NaverLandClusterClient, NaverLandFrontClient];
+const clients = [
+    NaverLandClusterClient,
+    NaverLandFrontClient,
+    NaverLandMapClient,
+];
 
 @Module({
     providers: [...clients],


### PR DESCRIPTION
네이버 부동산 지도 API 호출을 위한 Client를 추가합니다.

- 지도 Client 추가
- getRegionList API 추가
- 테스트 코드 추가